### PR TITLE
Extract font names into variables; remove "export" keyword

### DIFF
--- a/src/image-generator.sh
+++ b/src/image-generator.sh
@@ -3,12 +3,19 @@ CARD_W=785
 CARD_H=620
 STICKER_W=785
 STICKER_H=1222
+
 HEAD_FONT_SIZE=36
 DESC_FONT_SIZE=28
 EXAMPLE_FONT_SIZE=23
 NUMBER_FONT_SIZE=25
+HEAD_FONT=DejaVu-Sans-Bold
+DESC_FONT=$HEAD_FONT
+EXAMPLE_FONT=Liberation-Sans-Bold-Italic
+NUMBER_FONT=$HEAD_FONT
+
 COLORS=($(ls -1 colors/*.png))
 LANGUAGES=( rus eng )
+
 for lang in "${LANGUAGES[@]}"; do
     rm -rf cards-${lang} stickers-${lang} tts-${lang}
     sync
@@ -23,7 +30,7 @@ for lang in "${LANGUAGES[@]}"; do
                 # Background color
                 convert ${COLORS[$color_counter]} -resize ${CARD_W}x${CARD_H}\! ${card_file_prefix}-stage0.png
                 # Fallacy name
-                convert -background transparent -font DejaVu-Sans-Bold -pointsize ${HEAD_FONT_SIZE} -fill white \
+                convert -background transparent -font $HEAD_FONT -pointsize ${HEAD_FONT_SIZE} -fill white \
                     -gravity center -size ${CARD_W}x80 caption:"$line" ${card_file_prefix}-stage1-text.png
                 convert ${card_file_prefix}-stage0.png -page +0+10 ${card_file_prefix}-stage1-text.png \
                     -flatten ${card_file_prefix}-stage1.png
@@ -34,19 +41,19 @@ for lang in "${LANGUAGES[@]}"; do
                 ;;
             3)
                 # Fallacy description
-                convert -background transparent -font DejaVu-Sans-Bold -pointsize ${DESC_FONT_SIZE} -fill white \
+                convert -background transparent -font $DESC_FONT -pointsize ${DESC_FONT_SIZE} -fill white \
                     -gravity center -size 735x170 caption:"$line" ${card_file_prefix}-stage3-text.png
                 convert ${card_file_prefix}-stage2.png -page +25+110 ${card_file_prefix}-stage3-text.png \
                     -flatten ${card_file_prefix}-stage3.png
                 ;;
             4)
                 # Fallacy example
-                convert -background transparent -font Liberation-Sans-Bold-Italic -pointsize ${EXAMPLE_FONT_SIZE} \
+                convert -background transparent -font $EXAMPLE_FONT -pointsize ${EXAMPLE_FONT_SIZE} \
                     -fill white -gravity center -size 380x360 caption:"$line" ${card_file_prefix}-stage4-text.png
                 convert ${card_file_prefix}-stage3.png -page +315+270 ${card_file_prefix}-stage4-text.png \
                     -flatten ${card_file_prefix}-stage4.png
                 # Fallacy number
-                convert -background transparent -font DejaVu-Sans-Bold -pointsize ${NUMBER_FONT_SIZE} -fill white \
+                convert -background transparent -font $NUMBER_FONT -pointsize ${NUMBER_FONT_SIZE} -fill white \
                     -gravity center -size 40x30 caption:"$color_counter" ${card_file_prefix}-number.png
                 convert ${card_file_prefix}-stage4.png -page +740+580 ${card_file_prefix}-number.png \
                     -flatten ${card_file_prefix}-final.png

--- a/src/image-generator.sh
+++ b/src/image-generator.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-export CARD_W=785
-export CARD_H=620
-export STICKER_W=785
-export STICKER_H=1222
-export HEAD_FONT_SIZE=36
-export DESC_FONT_SIZE=28
-export EXAMPLE_FONT_SIZE=23
-export NUMBER_FONT_SIZE=25
-export COLORS=($(ls -1 colors/*.png))
-export LANGUAGES=( rus eng )
+CARD_W=785
+CARD_H=620
+STICKER_W=785
+STICKER_H=1222
+HEAD_FONT_SIZE=36
+DESC_FONT_SIZE=28
+EXAMPLE_FONT_SIZE=23
+NUMBER_FONT_SIZE=25
+COLORS=($(ls -1 colors/*.png))
+LANGUAGES=( rus eng )
 for lang in "${LANGUAGES[@]}"; do
     rm -rf cards-${lang} stickers-${lang} tts-${lang}
     sync


### PR DESCRIPTION
Попробовал запустить на macOS, столкнулся с проблемой нехватки шрифтов.

Установил шрифты, но имена получились другие, так что пришлось лезть в скрипт и исправлять. Так что немного упростил эту задачу для других людей - вынес названия шрифтов в переменные.